### PR TITLE
Feat/manage subdirs via module files

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -105,8 +105,8 @@ class puppet::master(
     recurse => true, # recursive mgmt
     purge => true, # purge unmanaged junk
     force => true, # including subdirs and links 
-    owner => "root",
-    group => "root",
+    #owner => "root",
+    #group => "root",
     mode => 0775, 
     source => "puppet:///modules/puppet/hieradata",
     #notify  => Service[$service_name], # should this notify?
@@ -118,8 +118,8 @@ class puppet::master(
     recurse => true, # recursive mgmt
     purge => true, # purge unmanaged junk
     force => true, # including subdirs and links 
-    owner => "root",
-    group => "root",
+    #owner => "root",
+    #group => "root",
     mode => 0775, 
     source => "puppet:///modules/puppet/environments",
     notify  => Service[$service_name], # should this notify?


### PR DESCRIPTION
Hello Vaidas. I've been using Puppet with Hiera to manage my own environments (with Vagrant and to build physical Hadoop clusters) for a while now and I've decided to use Puppet to manage remote Puppet servers. I found your module and was drawn to it because it's clean and uses Hiera. I extended it to allow me to pull in /etc/puppet/{hieradata, environments} from directories of the same name in the files section of the module. Based on the existence of this directory, I suspect you were planning to do the same. I also added /etc/puppet/graphs since I use that. 

Another idea, which is useful, but would take more time, would be to use Hiera to configure the module to create a Puppetfile per environment (i.e. /etc/puppet/environments/{environment}/Puppetfile) and then use librarian-puppet to populate the module directory. That has obvious tradeoffs too.

Anyway, thanks for the module. If you'd like to collaborate a bit on this, let me know.
